### PR TITLE
use relative path in findbugs

### DIFF
--- a/lib/dokumi/tool/android/findbugs.rb
+++ b/lib/dokumi/tool/android/findbugs.rb
@@ -12,7 +12,7 @@ module Dokumi
 
               report.xpath("//BugInstance").map do |info|
                 source_path = info.xpath("SourceLine/@sourcepath").first.to_s
-                file_path = Pathname.pwd.join(target_project, "src/main/java", source_path)
+                file_path = Pathname.new(target_project).join("src/main/java", source_path)
 
                 {
                     description: info.xpath("LongMessage/text()").first.to_s,

--- a/lib/dokumi/tool/android/findbugs.rb
+++ b/lib/dokumi/tool/android/findbugs.rb
@@ -12,7 +12,7 @@ module Dokumi
 
               report.xpath("//BugInstance").map do |info|
                 source_path = info.xpath("SourceLine/@sourcepath").first.to_s
-                file_path = Pathname.new(target_project).join("src/main/java", source_path)
+                file_path = Support.make_pathname(target_project).join("src/main/java", source_path)
 
                 {
                     description: info.xpath("LongMessage/text()").first.to_s,


### PR DESCRIPTION
[lib/dokumi/tool/android/findbugs.rb#L15](https://github.com/cookpad/dokumi/blob/master/lib/dokumi/tool/android/findbugs.rb#L15)で
`Pathname.pwd.join(target_project, "src/main/java", source_path)` として絶対パスをとっているのでdokumiのディレクトリとfindbugsが実行されるディレクトリが違う時に不整合が起きる
`Pathname.new(target_project).join("src/main/java", source_path)` とすればプロジェクトルートからのパスで扱うことが出来るのでディレクトリが一致していなくても正しく動く
