### PR TITLE
Android/Findbugsで優先度をチェックする

### DIFF
--- a/lib/dokumi/build_environment.rb
+++ b/lib/dokumi/build_environment.rb
@@ -41,13 +41,17 @@ module Dokumi
 
     VALID_ISSUE_TYPES = [:warning, :static_analysis, :error]
     def add_issue(new_issue)
-      Support.validate_hash new_issue, requires: [:type, :description], can_also_have: [:file_path, :line, :column]
+      Support.validate_hash new_issue, requires: [:type, :description], can_also_have: [:file_path, :line, :column, :priority]
       raise "an issue type has to be one of #{VALID_ISSUE_TYPES.inspect}" unless VALID_ISSUE_TYPES.include?(new_issue[:type])
 
       if new_issue[:file_path]
         file_path = Support.make_pathname(new_issue[:file_path])
         file_path = file_path.relative_path_from(source_directory) unless file_path.relative?
         new_issue = new_issue.merge(file_path: file_path)
+      end
+  
+      if new_issue[:type] != :static_analysis
+        new_issue[:priority] = 9
       end
 
       similar_issue_index = @issues.index do |compared_to|

--- a/lib/dokumi/command.rb
+++ b/lib/dokumi/command.rb
@@ -48,7 +48,7 @@ module Dokumi
         issues.each do |issue|
           Support.logger.warn "- #{issue[:file_path]}:#{issue[:line]}: #{issue[:description]}"
         end
-        if issues.all? {|issue| issue[:type] == :warning }
+        if issues.all? {|issue| issue[:type] == :warning || (issue[:type] == :static_analysis && issue[:priority].to_i > 1)}
           Support.logger.warn "warnings only - should be fixed but not considered a failure"
           exit true
         else

--- a/lib/dokumi/tool/android.rb
+++ b/lib/dokumi/tool/android.rb
@@ -22,6 +22,7 @@ module Dokumi
               line: bug[:line],
               type: :static_analysis,
               description: bug[:description],
+              priority: bug[:priority],
           )
         end
       end

--- a/lib/dokumi/tool/android/findbugs.rb
+++ b/lib/dokumi/tool/android/findbugs.rb
@@ -11,6 +11,7 @@ module Dokumi
               report = Nokogiri::XML(file)
 
               report.xpath("//BugInstance").map do |info|
+                priority = info.attribute('priority').value
                 source_path = info.xpath("SourceLine/@sourcepath").first.to_s
                 file_path = Support.make_pathname(target_project).join("src/main/java", source_path)
 
@@ -18,6 +19,7 @@ module Dokumi
                     description: info.xpath("LongMessage/text()").first.to_s,
                     file_path: file_path,
                     line: info.xpath("SourceLine/@start").first.to_s.to_i,
+                    priority: priority,
                 }
               end
             end


### PR DESCRIPTION
FindBugsで作成されるissueはtypeに`static_analysis`が付けられており、検出するとエラーと同等の扱いでCIが失敗するようになっている
このプルリクではFindBugsのレポートにある`priority`の値を参照し、`priority`が1よりも大きいものだけだった場合は警告と同じ扱いになるようにする
(findbugsのpriorityは1が一番高い)
- issue[:priority]を追加し、findbugsレポートのpriorityを入れる
- review_and_reportで`全て:warningか、:static_analysis且つissue[:priority]が全て1よりも大きい場合`はwarnings onlyとしてtrueを返す
