### PR TITLE
issueに項目':tool'を追加します

### DIFF
--- a/lib/dokumi/build_environment.rb
+++ b/lib/dokumi/build_environment.rb
@@ -41,8 +41,12 @@ module Dokumi
 
     VALID_ISSUE_TYPES = [:warning, :static_analysis, :error]
     def add_issue(new_issue)
-      Support.validate_hash new_issue, requires: [:type, :description], can_also_have: [:file_path, :line, :column]
+      Support.validate_hash new_issue, requires: [:type, :description, :tool], can_also_have: [:file_path, :line, :column]
       raise "an issue type has to be one of #{VALID_ISSUE_TYPES.inspect}" unless VALID_ISSUE_TYPES.include?(new_issue[:type])
+
+      if new_issue[:tool].nil?
+        new_issue[:tool] = :compiler
+      end
 
       if new_issue[:file_path]
         file_path = Support.make_pathname(new_issue[:file_path])

--- a/lib/dokumi/build_environment.rb
+++ b/lib/dokumi/build_environment.rb
@@ -41,7 +41,7 @@ module Dokumi
 
     VALID_ISSUE_TYPES = [:warning, :error]
     def add_issue(new_issue)
-      Support.validate_hash new_issue, requires: [:type, :description], can_also_have: [:file_path, :line, :column]
+      Support.validate_hash new_issue, requires: [:type, :description], can_also_have: [:file_path, :line, :column, :tool]
       raise "an issue type has to be one of #{VALID_ISSUE_TYPES.inspect}" unless VALID_ISSUE_TYPES.include?(new_issue[:type])
 
       new_issue[:tool] ||= :compiler

--- a/lib/dokumi/build_environment.rb
+++ b/lib/dokumi/build_environment.rb
@@ -41,12 +41,10 @@ module Dokumi
 
     VALID_ISSUE_TYPES = [:warning, :error]
     def add_issue(new_issue)
-      Support.validate_hash new_issue, requires: [:type, :description, :tool], can_also_have: [:file_path, :line, :column]
+      Support.validate_hash new_issue, requires: [:type, :description], can_also_have: [:file_path, :line, :column]
       raise "an issue type has to be one of #{VALID_ISSUE_TYPES.inspect}" unless VALID_ISSUE_TYPES.include?(new_issue[:type])
 
-      if new_issue[:tool].nil?
-        new_issue[:tool] = :compiler
-      end
+      new_issue[:tool] ||= :compiler
 
       if new_issue[:file_path]
         file_path = Support.make_pathname(new_issue[:file_path])
@@ -64,9 +62,9 @@ module Dokumi
 
       similar_issue = @issues[similar_issue_index]
 
-      # if a similar issue is present, keep the strongest type: error > static_analysis > warning
+      # if a similar issue is present, keep the strongest type: error > warning
       return if similar_issue[:type] == :error or similar_issue[:type] == new_issue[:type]
-      @issues[similar_issue_index] = new_issue if :error.include?(new_issue[:type])
+      @issues[similar_issue_index] = new_issue if new_issue[:type] == :error
     end
 
     def add_artifacts(*artifacts)

--- a/lib/dokumi/build_environment.rb
+++ b/lib/dokumi/build_environment.rb
@@ -39,7 +39,7 @@ module Dokumi
       end
     end
 
-    VALID_ISSUE_TYPES = [:warning, :static_analysis, :error]
+    VALID_ISSUE_TYPES = [:warning, :error]
     def add_issue(new_issue)
       Support.validate_hash new_issue, requires: [:type, :description, :tool], can_also_have: [:file_path, :line, :column]
       raise "an issue type has to be one of #{VALID_ISSUE_TYPES.inspect}" unless VALID_ISSUE_TYPES.include?(new_issue[:type])
@@ -66,7 +66,7 @@ module Dokumi
 
       # if a similar issue is present, keep the strongest type: error > static_analysis > warning
       return if similar_issue[:type] == :error or similar_issue[:type] == new_issue[:type]
-      @issues[similar_issue_index] = new_issue if [ :error, :static_analysis ].include?(new_issue[:type])
+      @issues[similar_issue_index] = new_issue if :error.include?(new_issue[:type])
     end
 
     def add_artifacts(*artifacts)

--- a/lib/dokumi/tool/android.rb
+++ b/lib/dokumi/tool/android.rb
@@ -20,7 +20,7 @@ module Dokumi
           @environment.add_issue(
               file_path: bug[:file_path],
               line: bug[:line],
-              type: bug[:type],
+              type: bug[:type].to_sym,
               description: bug[:description],
               tool: :findbugs,
           )

--- a/lib/dokumi/tool/android.rb
+++ b/lib/dokumi/tool/android.rb
@@ -35,8 +35,9 @@ module Dokumi
           @environment.add_issue(
               file_path: bug[:file_path],
               line: bug[:line],
-              type: :static_analysis,
+              type: :warning,
               description: bug[:description],
+              tool: :infer
           )
         end
       end

--- a/lib/dokumi/tool/android.rb
+++ b/lib/dokumi/tool/android.rb
@@ -20,8 +20,9 @@ module Dokumi
           @environment.add_issue(
               file_path: bug[:file_path],
               line: bug[:line],
-              type: :static_analysis,
+              type: bug[:type],
               description: bug[:description],
+              tool: :findbugs,
           )
         end
       end

--- a/lib/dokumi/tool/android/findbugs.rb
+++ b/lib/dokumi/tool/android/findbugs.rb
@@ -11,6 +11,7 @@ module Dokumi
               report = Nokogiri::XML(file)
 
               report.xpath("//BugInstance").map do |info|
+                priority = info.attribute('priority').value
                 source_path = info.xpath("SourceLine/@sourcepath").first.to_s
                 file_path = Support.make_pathname(target_project).join("src/main/java", source_path)
 
@@ -18,6 +19,7 @@ module Dokumi
                     description: info.xpath("LongMessage/text()").first.to_s,
                     file_path: file_path,
                     line: info.xpath("SourceLine/@start").first.to_s.to_i,
+                    type: priority.to_i > 1 ? :warning : :error,
                 }
               end
             end

--- a/lib/dokumi/tool/xcode.rb
+++ b/lib/dokumi/tool/xcode.rb
@@ -58,7 +58,7 @@ module Dokumi
               file_path: content["files"][location["file"]],
               line: location["line"].to_i,
               column: location["col"].to_i,
-              type: :static_analysis,
+              type: :warning,
               description: diagnostic["description"],
             )
           end

--- a/lib/dokumi/tool/xcode.rb
+++ b/lib/dokumi/tool/xcode.rb
@@ -59,6 +59,7 @@ module Dokumi
               line: location["line"].to_i,
               column: location["col"].to_i,
               type: :warning,
+              tool: :static_analyzer,
               description: diagnostic["description"],
             )
           end

--- a/lib/dokumi/version_control/github.rb
+++ b/lib/dokumi/version_control/github.rb
@@ -168,9 +168,9 @@ module Dokumi
           when :static_analysis
             "**Static Analysis:** #{issue[:description]}"
           when :warning
-            "**Warning:** #{issue[:description]}"
+            "**Warning(#{issue[:tool].to_s}):** #{issue[:description]}"
           when :error
-            "**Error:** #{issue[:description]}"
+            "**Error(#{issue[:tool].to_s}):** #{issue[:description]}"
           else
             raise "Unknown issue type #{issue[:type]}"
           end

--- a/lib/dokumi/version_control/github.rb
+++ b/lib/dokumi/version_control/github.rb
@@ -164,11 +164,12 @@ module Dokumi
 
         def self.markdown_for_issue(issue)
           Support.validate_hash issue, requires: [:type, :description]
+          tool_name = issue[:tool].to_s.capitalize.gsub(/_[a-z]/) {|string| " " + string[-1].upcase }
           case issue[:type]
           when :warning
-            "**Warning(#{issue[:tool].to_s}):** #{issue[:description]}"
+            "**#{tool_name} Warning:** #{issue[:description]}"
           when :error
-            "**Error(#{issue[:tool].to_s}):** #{issue[:description]}"
+            "**#{tool_name} Error:** #{issue[:description]}"
           else
             raise "Unknown issue type #{issue[:type]}"
           end

--- a/lib/dokumi/version_control/github.rb
+++ b/lib/dokumi/version_control/github.rb
@@ -165,8 +165,6 @@ module Dokumi
         def self.markdown_for_issue(issue)
           Support.validate_hash issue, requires: [:type, :description]
           case issue[:type]
-          when :static_analysis
-            "**Static Analysis:** #{issue[:description]}"
           when :warning
             "**Warning(#{issue[:tool].to_s}):** #{issue[:description]}"
           when :error

--- a/test/findbugs.rb
+++ b/test/findbugs.rb
@@ -15,8 +15,12 @@ class TestFindbugs < Minitest::Test
 
     issues.each do |issue|
       assert_equal Dokumi::Support.make_pathname("app/src/main/java/com/cookpad/android/dokumiTestAndroid/MainActivity.java"), issue[:file_path]
-      assert_equal :static_analysis, issue[:type]
+      assert_equal :findbugs, issue[:tool]
     end
+    assert_equal :error, issues[0][:type]
+    assert_equal :warning, issues[1][:type]
+    assert_equal :warning, issues[2][:type]
+    assert_equal :error, issues[3][:type]
     assert_equal 46, issues[0][:line]
     assert_equal 46, issues[1][:line]
     assert_equal 50, issues[2][:line]

--- a/test/infer.rb
+++ b/test/infer.rb
@@ -15,7 +15,8 @@ class TestInfer < Minitest::Test
 
     issues.each do |issue|
       assert_equal Dokumi::Support.make_pathname("app/src/main/java/com/cookpad/android/dokumiTestAndroid/MainActivity.java"), issue[:file_path]
-      assert_equal :static_analysis, issue[:type]
+      assert_equal :infer, issue[:tool]
+      assert_equal :warning, issue[:type]
     end
     assert_equal 52, issues[0][:line]
     assert_equal 71, issues[1][:line]

--- a/test/review_xcode_project.rb
+++ b/test/review_xcode_project.rb
@@ -36,7 +36,8 @@ class TestReviewXcodeProject < Minitest::Test
     assert_equal 1, issues.length
     issue = issues.first
     assert_equal Dokumi::Support.make_pathname("dokumi-test-ios/ViewController.m"), issue[:file_path]
-    assert_equal :static_analysis, issue[:type]
+    assert_equal :static_analyzer, issue[:tool]
+    assert_equal :warning, issue[:type]
   end
 
   def test_review_with_linker_error


### PR DESCRIPTION
どのツールからのerror/warningか解りやすくなる様にissueにtoolという項目を追加します
- issueにtoolという項目を追加し、デフォルト値を`: compiler`とします
- プルリクエストへのコメントにtoolを含めます
- findbugsではtoolを`:findbugs`とし、priorityが1のものを`error`、それ以外を`warning`として報告します
- issue[:type]の`:static_analysis`は使わなくなるので削除します ba4533b

新しいコメントの例

```
line 50: Warning(findbugs): 読み出されない public または protected フィールド: 
```
