### PR TITLE
[Android][Findbugs] use rank rather than priority

### DIFF
--- a/lib/dokumi/tool/android/findbugs.rb
+++ b/lib/dokumi/tool/android/findbugs.rb
@@ -12,7 +12,7 @@ module Dokumi
               report = Nokogiri::XML(file)
 
               report.xpath("//BugInstance").map do |info|
-                rank = info.attribute("rank").value
+                rank = info.attribute("rank").value.to_i
                 source_path = info.xpath("SourceLine/@sourcepath").first.to_s
                 file_path = Support.make_pathname(target_project).join("src/main/java", source_path)
 
@@ -20,7 +20,7 @@ module Dokumi
                     description: info.xpath("LongMessage/text()").first.to_s,
                     file_path: file_path,
                     line: info.xpath("SourceLine/@start").first.to_s.to_i,
-                    type: rank.to_i > RANK_ERROR_THRESHOLD ? :warning : :error,
+                    type: rank > RANK_ERROR_THRESHOLD ? :warning : :error,
                 }
               end
             end

--- a/lib/dokumi/tool/android/findbugs.rb
+++ b/lib/dokumi/tool/android/findbugs.rb
@@ -3,6 +3,7 @@ module Dokumi
     class Android
       class FindBugs
         FINDBUGS_REPORT_FILE = "build/reports/findbugs/findbugs.xml"
+        RANK_ERROR_THRESHOLD = 4
 
         class << self
           def parse_report(target_project)
@@ -11,7 +12,7 @@ module Dokumi
               report = Nokogiri::XML(file)
 
               report.xpath("//BugInstance").map do |info|
-                rank = info.attribute('rank').value
+                rank = info.attribute("rank").value
                 source_path = info.xpath("SourceLine/@sourcepath").first.to_s
                 file_path = Support.make_pathname(target_project).join("src/main/java", source_path)
 
@@ -19,7 +20,7 @@ module Dokumi
                     description: info.xpath("LongMessage/text()").first.to_s,
                     file_path: file_path,
                     line: info.xpath("SourceLine/@start").first.to_s.to_i,
-                    type: rank.to_i > 4 ? :warning : :error,
+                    type: rank.to_i > RANK_ERROR_THRESHOLD ? :warning : :error,
                 }
               end
             end

--- a/lib/dokumi/tool/android/findbugs.rb
+++ b/lib/dokumi/tool/android/findbugs.rb
@@ -11,7 +11,7 @@ module Dokumi
               report = Nokogiri::XML(file)
 
               report.xpath("//BugInstance").map do |info|
-                priority = info.attribute('priority').value
+                rank = info.attribute('rank').value
                 source_path = info.xpath("SourceLine/@sourcepath").first.to_s
                 file_path = Support.make_pathname(target_project).join("src/main/java", source_path)
 
@@ -19,7 +19,7 @@ module Dokumi
                     description: info.xpath("LongMessage/text()").first.to_s,
                     file_path: file_path,
                     line: info.xpath("SourceLine/@start").first.to_s.to_i,
-                    type: priority.to_i > 1 ? :warning : :error,
+                    type: rank.to_i > 4 ? :warning : :error,
                 }
               end
             end


### PR DESCRIPTION
findbugsでtypeをerrorにする基準を `priority` から `rank` に変更します
最も深刻な rank1〜4 のbugをerrorに、それ以外はwarningとして報告します

参考: [findbugs 第8章フィルターファイル 2.マッチング条件の種類](http://findbugs.sourceforge.net/ja/manual/filter.html#d0e1893)
