### PR TITLE
Implement benchmarker of external commands

### DIFF
--- a/lib/dokumi/command.rb
+++ b/lib/dokumi/command.rb
@@ -1,13 +1,13 @@
 module Dokumi
   module Command
     def self.archive(host, owner, repo, branch_or_tag_name, environment_options = {})
-      self.build_for(:archive, host, owner, repo, branch_or_tag_name, environment_options)
-      self.export_benchmark_report(environment_options)
+      build_for(:archive, host, owner, repo, branch_or_tag_name, environment_options)
+      export_benchmark_report(environment_options)
     end
 
     def self.test(host, owner, repo, branch_or_tag_name, environment_options = {})
-      self.build_for(:test, host, owner, repo, branch_or_tag_name, environment_options)
-      self.export_benchmark_report(environment_options)
+      build_for(:test, host, owner, repo, branch_or_tag_name, environment_options)
+      export_benchmark_report(environment_options)
     end
 
     def self.review(host, owner, repo, pull_request_number, environment_options = {})
@@ -24,14 +24,14 @@ module Dokumi
       diff = local_copy.diff_with_merge_base
       issues = diff.filter_out_unrelated_issues(environment.issues, lines_around_related: environment.lines_around_related)
       pull_request.add_comments_for_issues(issues, diff) unless environment_options[:skip_comment_creation]
-      self.export_benchmark_report(environment_options)
+      export_benchmark_report(environment_options)
 
       issues
     end
 
     def self.review_and_report(host, owner, repo, pull_request_number, environment_options)
       issues = review(host, owner, repo, pull_request_number, environment_options)
-      self.export_benchmark_report(environment_options)
+      export_benchmark_report(environment_options)
 
       if issues.length == 0
         Support.logger.info "great, no issue found"

--- a/lib/dokumi/command.rb
+++ b/lib/dokumi/command.rb
@@ -33,7 +33,6 @@ module Dokumi
       issues = review(host, owner, repo, pull_request_number, environment_options)
       self.export_benchmark_report(environment_options)
 
-
       if issues.length == 0
         Support.logger.info "great, no issue found"
         exit true

--- a/lib/dokumi/command.rb
+++ b/lib/dokumi/command.rb
@@ -2,10 +2,12 @@ module Dokumi
   module Command
     def self.archive(host, owner, repo, branch_or_tag_name, environment_options = {})
       self.build_for(:archive, host, owner, repo, branch_or_tag_name, environment_options)
+      self.export_benchmark_report(environment_options)
     end
 
     def self.test(host, owner, repo, branch_or_tag_name, environment_options = {})
       self.build_for(:test, host, owner, repo, branch_or_tag_name, environment_options)
+      self.export_benchmark_report(environment_options)
     end
 
     def self.review(host, owner, repo, pull_request_number, environment_options = {})
@@ -22,12 +24,15 @@ module Dokumi
       diff = local_copy.diff_with_merge_base
       issues = diff.filter_out_unrelated_issues(environment.issues, lines_around_related: environment.lines_around_related)
       pull_request.add_comments_for_issues(issues, diff) unless environment_options[:skip_comment_creation]
+      self.export_benchmark_report(environment_options)
 
       issues
     end
 
     def self.review_and_report(host, owner, repo, pull_request_number, environment_options)
       issues = review(host, owner, repo, pull_request_number, environment_options)
+      self.export_benchmark_report(environment_options)
+
 
       if issues.length == 0
         Support.logger.info "great, no issue found"
@@ -134,6 +139,12 @@ module Dokumi
       else
         nil
       end
+    end
+
+    def self.export_benchmark_report(environment_options)
+      filepath = environment_options[:benchmarker_export_path]
+      return unless filepath
+      Support.benchmarker.export!(filepath)
     end
   end
 end

--- a/lib/dokumi/command.rb
+++ b/lib/dokumi/command.rb
@@ -31,7 +31,6 @@ module Dokumi
 
     def self.review_and_report(host, owner, repo, pull_request_number, environment_options)
       issues = review(host, owner, repo, pull_request_number, environment_options)
-      export_benchmark_report(environment_options)
 
       if issues.length == 0
         Support.logger.info "great, no issue found"

--- a/lib/dokumi/support.rb
+++ b/lib/dokumi/support.rb
@@ -1,3 +1,4 @@
+require "dokumi/support/benchmark"
 require "dokumi/support/functions"
 require "dokumi/support/frozen_struct"
 require "dokumi/support/shell"

--- a/lib/dokumi/support/benchmark.rb
+++ b/lib/dokumi/support/benchmark.rb
@@ -31,10 +31,9 @@ module Dokumi
       end
 
       def export!(filename)
-        File.open(filename, 'w') do |file|
-          JSON.dump(data.map(&:to_hash), file)
-        end
-        Support.logger.info "#{filename} is exported"
+        json = JSON.pretty_generate(data.map(&:to_hash))
+        File.write(filename, json)
+        Support.logger.info "#{filename} has been exported"
       end
 
       def measure(*args, &block)

--- a/lib/dokumi/support/benchmark.rb
+++ b/lib/dokumi/support/benchmark.rb
@@ -25,7 +25,6 @@ module Dokumi
       end
     end
 
-
     class Benchmarker
       def initialize
         @data = []
@@ -40,9 +39,7 @@ module Dokumi
 
       def measure(command)
         timestamp = Time.now
-        tms = Benchmark.measure(command) do
-          yield
-        end
+        tms = Benchmark.measure(command) { yield }
         data << ExecutionLog.new(command, tms, timestamp)
       end
 
@@ -50,7 +47,6 @@ module Dokumi
       attr_accessor :data
     end
 
-    private
     def self.benchmarker
       return @benchmarker if @benchmarker
       @benchmarker = Benchmarker.new

--- a/lib/dokumi/support/benchmark.rb
+++ b/lib/dokumi/support/benchmark.rb
@@ -1,0 +1,45 @@
+require 'benchmark'
+require 'json'
+
+module Dokumi
+  module Support
+    class Benchmarker
+      attr_accessor :data
+
+      def initialize
+        @data = {}
+      end
+
+      def export!(filename)
+        output = @data.map do |command, tms|
+          {
+            command: command,
+            cstime: tms.cstime,
+            cutime: tms.cutime,
+            real: tms.real,
+            stime: tms.stime,
+            total: tms.total,
+            utime: tms.utime
+          }
+        end
+        File.open(filename, 'w') do |file|
+          JSON.dump(output, file)
+        end
+        Support.logger.info "#{filename} is exported"
+      end
+    end
+
+    def self.measure(label)
+      tms = Benchmark.measure(label) do
+        yield
+      end
+      benchmarker.data[label] = tms
+    end
+
+    private
+    def self.benchmarker
+      return @benchmarker if @benchmarker
+      @benchmarker = Benchmarker.new
+    end
+  end
+end

--- a/lib/dokumi/support/benchmark.rb
+++ b/lib/dokumi/support/benchmark.rb
@@ -3,37 +3,51 @@ require 'json'
 
 module Dokumi
   module Support
-    class Benchmarker
-      attr_accessor :data
+    class ExecutionLog
+      attr_reader :command, :tms, :timestamp
 
-      def initialize
-        @data = {}
+      def initialize(command, tms, timestamp)
+        @command = command
+        @tms = tms
+        @timestamp = timestamp
       end
 
-      def export!(filename)
-        output = @data.map do |command, tms|
-          {
-            command: command,
-            cstime: tms.cstime,
-            cutime: tms.cutime,
-            real: tms.real,
-            stime: tms.stime,
-            total: tms.total,
-            utime: tms.utime
-          }
-        end
-        File.open(filename, 'w') do |file|
-          JSON.dump(output, file)
-        end
-        Support.logger.info "#{filename} is exported"
+      def to_hash
+        { command: command,
+          cstime: tms.cstime,
+          cutime: tms.cutime,
+          real: tms.real,
+          stime: tms.stime,
+          total: tms.total,
+          utime: tms.utime,
+          timestamp: timestamp.to_i,
+        }
       end
     end
 
-    def self.measure(label)
-      tms = Benchmark.measure(label) do
-        yield
+
+    class Benchmarker
+      def initialize
+        @data = []
       end
-      benchmarker.data[label] = tms
+
+      def export!(filename)
+        File.open(filename, 'w') do |file|
+          JSON.dump(data.map(&:to_hash), file)
+        end
+        Support.logger.info "#{filename} is exported"
+      end
+
+      def measure(command)
+        timestamp = Time.now
+        tms = Benchmark.measure(command) do
+          yield
+        end
+        data << ExecutionLog.new(command, tms, timestamp)
+      end
+
+      private
+      attr_accessor :data
     end
 
     private

--- a/lib/dokumi/support/shell.rb
+++ b/lib/dokumi/support/shell.rb
@@ -21,7 +21,7 @@ module Dokumi
         Support.logger.debug "reading outputs of #{args.inspect}"
         exit_status = nil
         with_clean_env do
-          Support.measure(args.join(' ')) do
+          Support.benchmarker.measure(args.join(' ')) do
             exit_status = Open3.popen3(*args) do |stdin, stdout, stderr, wait_thread|
               stdin.close
               to_read = [stdout, stderr]
@@ -56,7 +56,7 @@ module Dokumi
         args = stringify_shell_arguments(args)
         Support.logger.debug "running #{args.inspect}"
         with_clean_env do
-          Support.measure(args.join(' ')) do
+          Support.benchmarker.measure(args.join(' ')) do
             system(*args)
           end
         end

--- a/lib/dokumi/support/shell.rb
+++ b/lib/dokumi/support/shell.rb
@@ -21,7 +21,7 @@ module Dokumi
         Support.logger.debug "reading outputs of #{args.inspect}"
         exit_status = nil
         with_clean_env do
-          Support.benchmarker.measure(args.join(' ')) do
+          Support.benchmarker.measure(*args) do
             exit_status = Open3.popen3(*args) do |stdin, stdout, stderr, wait_thread|
               stdin.close
               to_read = [stdout, stderr]
@@ -56,7 +56,7 @@ module Dokumi
         args = stringify_shell_arguments(args)
         Support.logger.debug "running #{args.inspect}"
         with_clean_env do
-          Support.benchmarker.measure(args.join(' ')) do
+          Support.benchmarker.measure(*args) do
             system(*args)
           end
         end

--- a/lib/dokumi/support/shell.rb
+++ b/lib/dokumi/support/shell.rb
@@ -21,31 +21,33 @@ module Dokumi
         Support.logger.debug "reading outputs of #{args.inspect}"
         exit_status = nil
         with_clean_env do
-          exit_status = Open3.popen3(*args) do |stdin, stdout, stderr, wait_thread|
-            stdin.close
-            to_read = [stdout, stderr]
-            until to_read.empty?
-              available, _, _ = IO.select(to_read)
-              while io = available.pop
-                if io.eof?
-                  io.close
-                  to_read.delete io
-                  next
-                end
-                case io
-                when stderr
-                  yield :error, io.gets
-                when stdout
-                  yield :output, io.gets
+          Support.measure(args.join(' ')) do
+            exit_status = Open3.popen3(*args) do |stdin, stdout, stderr, wait_thread|
+              stdin.close
+              to_read = [stdout, stderr]
+              until to_read.empty?
+                available, _, _ = IO.select(to_read)
+                while io = available.pop
+                  if io.eof?
+                    io.close
+                    to_read.delete io
+                    next
+                  end
+                  case io
+                    when stderr
+                      yield :error, io.gets
+                    when stdout
+                      yield :output, io.gets
+                  end
                 end
               end
+              wait_thread.value
             end
-            wait_thread.value
           end
+          exit_code = exit_status.exitstatus
+          raise "#{args.inspect} exited in error: #{exit_status.inspect}" if exit_code != 0 and !options[:allow_errors]
+          exit_code
         end
-        exit_code = exit_status.exitstatus
-        raise "#{args.inspect} exited in error: #{exit_status.inspect}" if exit_code != 0 and !options[:allow_errors]
-        exit_code
       end
 
       def self.run(*args)
@@ -54,7 +56,9 @@ module Dokumi
         args = stringify_shell_arguments(args)
         Support.logger.debug "running #{args.inspect}"
         with_clean_env do
-          system(*args)
+          Support.measure(args.join(' ')) do
+            system(*args)
+          end
         end
         exit_status = $?
         exit_code = exit_status.exitstatus


### PR DESCRIPTION
I implement benchmarker for the execution time of external commands.
## Usage

``` sh
bin/archive --benchmarker_export_path=execute_time.json
```
# Example

``` json
[
  {
    "command": "git fetch origin",
    "cstime": 0.020000000000000004,
    "cutime": 0.030000000000000002,
    "real": 0.7739903469919227,
    "stime": 0,
    "total": 0.05,
    "utime": 0,
    "timestamp": 1477027094
  },
  .....
]

```
